### PR TITLE
Using 3.2.1 minified version

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -82,7 +82,7 @@ export default class Omniture extends React.Component {
     return (
       <script
         type="text/javascript"
-        src="https://cdn.static-economist.com/sites/default/files/external/ec_omniture/3_2/ec_omniture_s_code.js"
+        src="https://cdn.static-economist.com/sites/default/files/external/ec_omniture/3_2_1/ec_omniture_s_code.min.js"
       ></script>
     );
   }


### PR DESCRIPTION
- Modified Omniture code to fix the below error case:

From the external network log-in as "Economist staff user".
Tapping on the landing page there is a blocking JS error.
The user cannot see the articles but the url change.

The error is related to the omniture code.
On row 268 of 3.2 ec_omniture_s_code.js ec_omniture_user_sub_info[1].split('|'); create an error because ec_omniture_user_sub_info[1] is undefined.

This happens because the props ec_omniture_user_sub in the cookie doesn't contains the expected entitlements strings, see...

// Prop54 gets the second bit, which is
// [registered_date]|[sub_end_date]|[entitlement_subscription_code]
s.prop54 = ec_omniture_user_sub_info[1];
- Minified omniture code
